### PR TITLE
Add Vitest setup and basic unit tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
     "dev": "vite",
     "build": "tsc -b && vite build",
     "lint": "eslint .",
-    "preview": "vite preview"
+    "preview": "vite preview",
+    "test": "vitest run"
   },
   "dependencies": {
     "@radix-ui/react-radio-group": "^1.3.7",
@@ -45,6 +46,7 @@
     "tw-animate-css": "^1.3.4",
     "typescript": "~5.8.3",
     "typescript-eslint": "^8.30.1",
-    "vite": "^6.3.5"
+    "vite": "^6.3.5",
+    "vitest": "^3.2.4"
   }
 }

--- a/src/lib/fakeApi.test.ts
+++ b/src/lib/fakeApi.test.ts
@@ -1,0 +1,21 @@
+import { describe, it, expect } from 'vitest';
+import { FakeAPI } from './fakeApi';
+
+describe('FakeAPI', () => {
+  it('sendOtp resolves for valid username', async () => {
+    await expect(FakeAPI.sendOtp('user')).resolves.toBeUndefined();
+  });
+
+  it('sendOtp rejects for invalid username', async () => {
+    await expect(FakeAPI.sendOtp('')).rejects.toThrowError();
+    await expect(FakeAPI.sendOtp('fail')).rejects.toThrowError();
+  });
+
+  it('verifyOtp resolves for correct otp', async () => {
+    await expect(FakeAPI.verifyOtp('123456')).resolves.toBeUndefined();
+  });
+
+  it('verifyOtp rejects for incorrect otp', async () => {
+    await expect(FakeAPI.verifyOtp('000000')).rejects.toThrowError();
+  });
+});

--- a/src/lib/utils.test.ts
+++ b/src/lib/utils.test.ts
@@ -1,0 +1,12 @@
+import { describe, it, expect } from 'vitest';
+import { cn } from './utils';
+
+describe('cn', () => {
+  it('merges class names', () => {
+    expect(cn('a', 'b')).toBe('a b');
+  });
+
+  it('ignores falsy values', () => {
+    expect(cn('a', undefined, '', 'c')).toBe('a c');
+  });
+});

--- a/src/store/authStore.test.ts
+++ b/src/store/authStore.test.ts
@@ -1,0 +1,28 @@
+import { describe, it, expect, afterEach } from 'vitest';
+import { useAuthStore } from './authStore';
+
+afterEach(() => {
+  useAuthStore.setState({
+    step: 1,
+    username: '',
+    otp: '',
+    isAuthenticated: false,
+    otpExpired: false,
+  });
+});
+
+describe('useAuthStore', () => {
+  it('has default values', () => {
+    const state = useAuthStore.getState();
+    expect(state.step).toBe(1);
+    expect(state.username).toBe('');
+    expect(state.otp).toBe('');
+    expect(state.isAuthenticated).toBe(false);
+    expect(state.otpExpired).toBe(false);
+  });
+
+  it('updates username', () => {
+    useAuthStore.getState().setUsername('john');
+    expect(useAuthStore.getState().username).toBe('john');
+  });
+});

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,4 +1,4 @@
-import { defineConfig } from "vite";
+import { defineConfig } from "vitest/config";
 import react from "@vitejs/plugin-react";
 import path from "path";
 
@@ -8,5 +8,9 @@ export default defineConfig({
     alias: {
       "@": path.resolve(__dirname, "src"),
     },
+  },
+  test: {
+    globals: true,
+    environment: "node",
   },
 });


### PR DESCRIPTION
## Summary
- set up Vitest in `vite.config.ts` and `package.json`
- add tests for `FakeAPI`, `cn` utility, and auth store

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_6858d8e1ad888328a156b6c39270f912