### PR TITLE
Add Playwright UI test setup

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -33,6 +33,7 @@
       },
       "devDependencies": {
         "@eslint/js": "^9.25.0",
+        "@playwright/test": "^1.42.1",
         "@rollup/plugin-alias": "^5.1.1",
         "@tailwindcss/postcss": "^4.1.10",
         "@types/node": "^24.0.3",
@@ -1140,6 +1141,22 @@
       },
       "engines": {
         "node": ">= 8"
+      }
+    },
+    "node_modules/@playwright/test": {
+      "version": "1.53.1",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.53.1.tgz",
+      "integrity": "sha512-Z4c23LHV0muZ8hfv4jw6HngPJkbbtZxTkxPNIg7cJcTc9C28N/p2q7g3JZS2SiKBBHJ3uM1dgDye66bB7LEk5w==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright": "1.53.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@radix-ui/number": {
@@ -4792,6 +4809,53 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.53.1",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.53.1.tgz",
+      "integrity": "sha512-LJ13YLr/ocweuwxyGf1XNFWIU4M2zUSo149Qbp+A4cpwDjsxRPj7k6H25LBrEHiEwxvRbD8HdwvQmRMSvquhYw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.53.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.53.1",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.53.1.tgz",
+      "integrity": "sha512-Z46Oq7tLAyT0lGoFx4DOuB1IA9D1TPj0QkYxpPVUnGDqHHvDpCftu1J2hM2PiWsNMoZh8+LQaarAWcDfPBc6zg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/playwright/node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
     "node_modules/postcss": {

--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
     "build": "tsc -b && vite build",
     "lint": "eslint .",
     "preview": "vite preview",
-    "test": "vitest run"
+    "test": "vitest run",
+    "test:e2e": "playwright test"
   },
   "dependencies": {
     "@hookform/resolvers": "^5.1.1",
@@ -53,6 +54,7 @@
     "typescript": "~5.8.3",
     "typescript-eslint": "^8.30.1",
     "vite": "^6.3.5",
-    "vitest": "^3.2.4"
+    "vitest": "^3.2.4",
+    "@playwright/test": "^1.42.1"
   }
 }

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,0 +1,19 @@
+import { defineConfig, devices } from '@playwright/test';
+
+export default defineConfig({
+  testDir: './tests/e2e',
+  fullyParallel: true,
+  use: {
+    baseURL: 'http://localhost:5173',
+    headless: true,
+  },
+  projects: [
+    { name: 'chromium', use: { ...devices['Desktop Chrome'] } },
+  ],
+  webServer: {
+    command: 'npm run dev -- --port 5173',
+    url: 'http://localhost:5173',
+    reuseExistingServer: !process.env.CI,
+    timeout: 120 * 1000,
+  },
+});

--- a/tests/e2e/auth-flow.spec.ts
+++ b/tests/e2e/auth-flow.spec.ts
@@ -1,0 +1,88 @@
+import { test, expect } from '@playwright/test';
+
+const loginResponseRegistered = {
+  success: true,
+  error: null,
+  count: null,
+  data: { mfaRegistered: true, sessionToken: 'abc' }
+};
+
+const loginResponseNotRegistered = {
+  success: true,
+  error: null,
+  count: null,
+  data: { mfaRegistered: false, sessionToken: 'abc' }
+};
+
+const registerMfaResponse = {
+  success: true,
+  error: null,
+  count: null,
+  data: { secret: 'secret', qrCodeImageBase64: 'dGVzdA==' }
+};
+
+const verifyOtpResponse = {
+  success: true,
+  error: null,
+  count: null,
+  data: { token: 'token', refresh: 'refresh' }
+};
+
+test.describe('Authentication flow', () => {
+  test('login with existing MFA', async ({ page }) => {
+    await page.route('**/auth/login', route => route.fulfill({
+      status: 200,
+      body: JSON.stringify(loginResponseRegistered),
+      contentType: 'application/json'
+    }));
+    await page.route('**/auth/verify-totp', route => route.fulfill({
+      status: 200,
+      body: JSON.stringify(verifyOtpResponse),
+      contentType: 'application/json'
+    }));
+
+    await page.goto('/');
+    await page.getByLabel('Username').fill('john');
+    await page.getByLabel('Password').fill('secret');
+    await page.getByRole('button', { name: /login/i }).click();
+
+    await expect(page.getByText('Enter the 6-digit OTP')).toBeVisible();
+
+    await page.locator('input[data-input-otp]').fill('123456');
+    await page.getByRole('button', { name: /verify otp/i }).click();
+
+    await expect(page.getByText('Welcome, john!')).toBeVisible();
+  });
+
+  test('register MFA when not configured', async ({ page }) => {
+    await page.route('**/auth/login', route => route.fulfill({
+      status: 200,
+      body: JSON.stringify(loginResponseNotRegistered),
+      contentType: 'application/json'
+    }));
+    await page.route('**/auth/register-mfa/**', route => route.fulfill({
+      status: 200,
+      body: JSON.stringify(registerMfaResponse),
+      contentType: 'application/json'
+    }));
+    await page.route('**/auth/verify-totp', route => route.fulfill({
+      status: 200,
+      body: JSON.stringify(verifyOtpResponse),
+      contentType: 'application/json'
+    }));
+
+    await page.goto('/');
+    await page.getByLabel('Username').fill('alice');
+    await page.getByLabel('Password').fill('secret');
+    await page.getByRole('button', { name: /login/i }).click();
+
+    await expect(page.getByText('Scan with Authenticator')).toBeVisible();
+    await page.getByRole('button', { name: "I've Scanned the QR Code" }).click();
+
+    await expect(page.getByText('Enter the 6-digit OTP')).toBeVisible();
+    await page.locator('input[data-input-otp]').fill('654321');
+    await page.getByRole('button', { name: /verify otp/i }).click();
+
+    await expect(page.getByText('Welcome, alice!')).toBeVisible();
+  });
+});

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,4 +1,4 @@
-import { defineConfig } from "vitest/config";
+import { defineConfig, configDefaults } from "vitest/config";
 import react from "@vitejs/plugin-react";
 import path from "path";
 
@@ -12,5 +12,6 @@ export default defineConfig({
   test: {
     globals: true,
     environment: "node",
+    exclude: [...configDefaults.exclude, "tests/e2e/**/*"],
   },
 });


### PR DESCRIPTION
## Summary
- add Playwright dev dependency and test:e2e script
- configure vitest to ignore e2e specs
- add basic Playwright config
- add e2e tests that mock API routes

## Testing
- `npm run test`
- `npm run test:e2e` *(fails: browser download blocked)*

------
https://chatgpt.com/codex/tasks/task_e_685b73285e488328a47899c39e0a3ff6