### PR TITLE
Add tenant selection for login

### DIFF
--- a/src/components/auth/AuthForm.tsx
+++ b/src/components/auth/AuthForm.tsx
@@ -12,6 +12,7 @@ import { toast } from "sonner";
 import { z } from "zod";
 import { LogIn } from "lucide-react";
 import { AuthService } from "@/lib/api/auth/service";
+import { DEFAULT_TENANT_ID } from "@/lib/api";
 
 const loginSchema = z.object({
   username: z.string().min(1, "Username is required."),
@@ -22,7 +23,9 @@ const loginSchema = z.object({
 export default function AuthForm() {
   const { username, setUsername, setStep, setSessionToken } = useAuthStore();
   const [password, setPassword] = useState("");
-  const [tenantId, setTenantId] = useState("11111111-1111-1111-1111-111111111111");
+  const [tenantId, setTenantId] = useState(
+    "11111111-1111-1111-1111-111111111111"
+  );
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState("");
 
@@ -101,19 +104,29 @@ export default function AuthForm() {
       </div>
 
       {/* Tenant dropdown */}
-      <Select value={tenantId} onValueChange={setTenantId}>
-        <SelectTrigger id="tenant" className="w-full">
-          <SelectValue placeholder="Select tenant" />
-        </SelectTrigger>
-        <SelectContent>
-          <SelectItem value="11111111-1111-1111-1111-111111111111">
-            Tenant 1
-          </SelectItem>
-          <SelectItem value="22222222-2222-2222-2222-222222222222">
-            Tenant 2
-          </SelectItem>
-        </SelectContent>
-      </Select>
+      <div className="relative w-full">
+        <label
+          htmlFor="tenant"
+          className="absolute left-3 top-1 text-xs text-muted-foreground transition-all 
+      peer-placeholder-shown:top-[10px] 
+      peer-placeholder-shown:text-sm 
+      peer-placeholder-shown:text-gray-400 
+      peer-focus:top-1 
+      peer-focus:text-xs 
+      peer-focus:text-blue-500"
+        >
+          Tenant
+        </label>
+
+        <Select value={tenantId} onValueChange={setTenantId}>
+          <SelectTrigger id="tenant" className="peer">
+            <SelectValue placeholder=" " />
+          </SelectTrigger>
+          <SelectContent>
+            <SelectItem value={DEFAULT_TENANT_ID}>Test Tenant</SelectItem>
+          </SelectContent>
+        </Select>
+      </div>
 
       {/* Login button */}
       <Button

--- a/src/components/auth/AuthForm.tsx
+++ b/src/components/auth/AuthForm.tsx
@@ -1,5 +1,12 @@
 import { useState } from "react";
 import { Button } from "@/components/ui/button";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
 import { useAuthStore } from "@/store/authStore";
 import { toast } from "sonner";
 import { z } from "zod";
@@ -9,16 +16,18 @@ import { AuthService } from "@/lib/api/auth/service";
 const loginSchema = z.object({
   username: z.string().min(1, "Username is required."),
   password: z.string().min(1, "Password is required."),
+  tenantId: z.string().min(1, "Tenant is required."),
 });
 
 export default function AuthForm() {
   const { username, setUsername, setStep, setSessionToken } = useAuthStore();
   const [password, setPassword] = useState("");
+  const [tenantId, setTenantId] = useState("11111111-1111-1111-1111-111111111111");
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState("");
 
   const handleLogin = async () => {
-    const result = loginSchema.safeParse({ username, password });
+    const result = loginSchema.safeParse({ username, password, tenantId });
 
     if (!result.success) {
       const firstError =
@@ -30,7 +39,7 @@ export default function AuthForm() {
     setError("");
     setLoading(true);
     try {
-      const { data } = await AuthService.login(username, password);
+      const { data } = await AuthService.login(username, password, tenantId);
 
       // toast.success("Login successful!");
       setStep(data.mfaRegistered ? 3 : 2);
@@ -90,6 +99,21 @@ export default function AuthForm() {
           Password
         </label>
       </div>
+
+      {/* Tenant dropdown */}
+      <Select value={tenantId} onValueChange={setTenantId}>
+        <SelectTrigger id="tenant" className="w-full">
+          <SelectValue placeholder="Select tenant" />
+        </SelectTrigger>
+        <SelectContent>
+          <SelectItem value="11111111-1111-1111-1111-111111111111">
+            Tenant 1
+          </SelectItem>
+          <SelectItem value="22222222-2222-2222-2222-222222222222">
+            Tenant 2
+          </SelectItem>
+        </SelectContent>
+      </Select>
 
       {/* Login button */}
       <Button

--- a/src/components/ui/select.tsx
+++ b/src/components/ui/select.tsx
@@ -1,25 +1,25 @@
-import * as React from "react"
-import * as SelectPrimitive from "@radix-ui/react-select"
-import { CheckIcon, ChevronDownIcon, ChevronUpIcon } from "lucide-react"
+import * as React from "react";
+import * as SelectPrimitive from "@radix-ui/react-select";
+import { CheckIcon, ChevronDownIcon, ChevronUpIcon } from "lucide-react";
 
-import { cn } from "@/lib/utils"
+import { cn } from "@/lib/utils";
 
 function Select({
   ...props
 }: React.ComponentProps<typeof SelectPrimitive.Root>) {
-  return <SelectPrimitive.Root data-slot="select" {...props} />
+  return <SelectPrimitive.Root data-slot="select" {...props} />;
 }
 
 function SelectGroup({
   ...props
 }: React.ComponentProps<typeof SelectPrimitive.Group>) {
-  return <SelectPrimitive.Group data-slot="select-group" {...props} />
+  return <SelectPrimitive.Group data-slot="select-group" {...props} />;
 }
 
 function SelectValue({
   ...props
 }: React.ComponentProps<typeof SelectPrimitive.Value>) {
-  return <SelectPrimitive.Value data-slot="select-value" {...props} />
+  return <SelectPrimitive.Value data-slot="select-value" {...props} />;
 }
 
 function SelectTrigger({
@@ -28,14 +28,24 @@ function SelectTrigger({
   children,
   ...props
 }: React.ComponentProps<typeof SelectPrimitive.Trigger> & {
-  size?: "sm" | "default"
+  size?: "sm" | "default";
 }) {
   return (
     <SelectPrimitive.Trigger
       data-slot="select-trigger"
       data-size={size}
       className={cn(
-        "border-input data-[placeholder]:text-muted-foreground [&_svg:not([class*='text-'])]:text-muted-foreground focus-visible:border-ring focus-visible:ring-ring/50 aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive dark:bg-input/30 dark:hover:bg-input/50 flex w-fit items-center justify-between gap-2 rounded-md border bg-transparent px-3 py-2 text-sm whitespace-nowrap shadow-xs transition-[color,box-shadow] outline-none focus-visible:ring-[3px] disabled:cursor-not-allowed disabled:opacity-50 data-[size=default]:h-9 data-[size=sm]:h-8 *:data-[slot=select-value]:line-clamp-1 *:data-[slot=select-value]:flex *:data-[slot=select-value]:items-center *:data-[slot=select-value]:gap-2 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
+        // 🔽 override size to match input field
+        "h-[44px] pt-4 px-3 text-sm",
+        // 🔽 input-like styling
+        "flex w-full items-center justify-between gap-2 rounded-md border border-input bg-background shadow-sm transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 focus-visible:ring-offset-2",
+        // 🔽 clean placeholder support
+        "data-[placeholder]:text-gray-400",
+        // 🔽 clean disabled/focus
+        "disabled:cursor-not-allowed disabled:opacity-50",
+        // 🔽 icon + value spacing
+        "*:data-[slot=select-value]:flex *:data-[slot=select-value]:items-center *:data-[slot=select-value]:gap-2",
+        "[&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
         className
       )}
       {...props}
@@ -45,7 +55,7 @@ function SelectTrigger({
         <ChevronDownIcon className="size-4 opacity-50" />
       </SelectPrimitive.Icon>
     </SelectPrimitive.Trigger>
-  )
+  );
 }
 
 function SelectContent({
@@ -80,7 +90,7 @@ function SelectContent({
         <SelectScrollDownButton />
       </SelectPrimitive.Content>
     </SelectPrimitive.Portal>
-  )
+  );
 }
 
 function SelectLabel({
@@ -93,7 +103,7 @@ function SelectLabel({
       className={cn("text-muted-foreground px-2 py-1.5 text-xs", className)}
       {...props}
     />
-  )
+  );
 }
 
 function SelectItem({
@@ -117,7 +127,7 @@ function SelectItem({
       </span>
       <SelectPrimitive.ItemText>{children}</SelectPrimitive.ItemText>
     </SelectPrimitive.Item>
-  )
+  );
 }
 
 function SelectSeparator({
@@ -130,7 +140,7 @@ function SelectSeparator({
       className={cn("bg-border pointer-events-none -mx-1 my-1 h-px", className)}
       {...props}
     />
-  )
+  );
 }
 
 function SelectScrollUpButton({
@@ -148,7 +158,7 @@ function SelectScrollUpButton({
     >
       <ChevronUpIcon className="size-4" />
     </SelectPrimitive.ScrollUpButton>
-  )
+  );
 }
 
 function SelectScrollDownButton({
@@ -166,7 +176,7 @@ function SelectScrollDownButton({
     >
       <ChevronDownIcon className="size-4" />
     </SelectPrimitive.ScrollDownButton>
-  )
+  );
 }
 
 export {
@@ -180,4 +190,4 @@ export {
   SelectSeparator,
   SelectTrigger,
   SelectValue,
-}
+};

--- a/src/lib/api/auth/service.ts
+++ b/src/lib/api/auth/service.ts
@@ -4,10 +4,11 @@ import type { LoginResponse } from "../models/login-response.model";
 import type { RegisterMfaResponse } from "../models/register-mfa-response.model";
 import type { VerifyOtpResponse } from "../models/verify-otp-response.model";
 export const AuthService = {
-  login: async (username: string, password: string) => {
+  login: async (username: string, password: string, tenantId: string) => {
     const response = await axios.post(AuthEndpoints.login, {
       username,
       password,
+      tenantId,
     });
     return response.data as LoginResponse;
   },

--- a/src/lib/api/index.ts
+++ b/src/lib/api/index.ts
@@ -1,2 +1,3 @@
 // Base API setup
 export const API_BASE_URL = "https://localhost:5081/api";
+export const DEFAULT_TENANT_ID = "11111111-1111-1111-1111-111111111111";

--- a/tests/auth.spec.ts
+++ b/tests/auth.spec.ts
@@ -37,6 +37,8 @@ test("login with OTP or QR", async ({ page }) => {
   await page.goto("/login");
   await page.fill("#username", "admin");
   await page.fill("#password", "admin");
+  await page.getByRole("combobox").click();
+  await page.getByRole("option", { name: "Tenant 1" }).click();
   await page.getByRole("button", { name: /login/i }).click();
 
   const otp = page.getByText("Enter the 6-digit OTP");
@@ -64,6 +66,8 @@ test("logout resets session", async ({ page }) => {
   await page.goto("/login");
   await page.fill("#username", "admin");
   await page.fill("#password", "admin");
+  await page.getByRole("combobox").click();
+  await page.getByRole("option", { name: "Tenant 1" }).click();
   await page.getByRole("button", { name: /login/i }).click();
 
   const otp = page.getByText("Enter the 6-digit OTP");


### PR DESCRIPTION
## Summary
- support tenantId in AuthService.login
- update AuthForm with tenant dropdown using shadcn Select
- adjust Playwright tests for new dropdown

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_685cdbe582e88328962147ad24b08446