### PR TITLE
Persist auth state with Zustand

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -8,6 +8,6 @@ export default function App() {
     document.title = "Chodex";
   }, []);
 
-  const { isAuthenticated } = useAuthStore();
-  return isAuthenticated ? <HomePage /> : <AuthPage />;
+  const { isAuthenticated, token } = useAuthStore();
+  return isAuthenticated && token ? <HomePage /> : <AuthPage />;
 }

--- a/src/components/auth/OTPForm.tsx
+++ b/src/components/auth/OTPForm.tsx
@@ -21,6 +21,9 @@ export default function OTPForm() {
     sessionToken,
     setOtp,
     setAuthenticated,
+    setToken,
+    setUser,
+    username,
     otpExpired,
     setStep,
     setUsername,
@@ -46,6 +49,8 @@ export default function OTPForm() {
         return;
       }
 
+      setToken(response.data.token);
+      setUser(username);
       setAuthenticated(true);
     } catch (err) {
       const error = err as AxiosError<{ error: string }>;

--- a/src/components/pages/Home.tsx
+++ b/src/components/pages/Home.tsx
@@ -3,17 +3,17 @@ import { Button } from "@/components/ui/button";
 import { HomeIcon, LogOut } from "lucide-react";
 
 export default function HomePage() {
-  const { username, reset } = useAuthStore();
+  const { user, username, logout } = useAuthStore();
 
   const handleLogout = () => {
-    reset();
+    logout();
   };
 
   return (
     <div className="flex flex-col items-center justify-center h-screen space-y-6">
       <div className="flex items-center gap-2 text-2xl font-bold">
         <HomeIcon className="w-6 h-6" />
-        Welcome, {username || "User"}!
+        Welcome, {user || username || "User"}!
       </div>
       <Button onClick={handleLogout}>
         <LogOut className="w-4 h-4 mr-2" />

--- a/src/store/authStore.test.ts
+++ b/src/store/authStore.test.ts
@@ -7,6 +7,9 @@ afterEach(() => {
     username: '',
     tenantId: '11111111-1111-1111-1111-111111111111',
     otp: '',
+    sessionToken: '',
+    token: '',
+    user: '',
     isAuthenticated: false,
     otpExpired: false,
   });

--- a/src/store/authStore.ts
+++ b/src/store/authStore.ts
@@ -1,4 +1,5 @@
 import { create } from "zustand";
+import { persist } from "zustand/middleware";
 import { DEFAULT_TENANT_ID } from "@/lib/api";
 
 interface AuthState {
@@ -8,6 +9,8 @@ interface AuthState {
   tenantId: string;
   otp: string;
   sessionToken: string;
+  token: string;
+  user: string;
   isAuthenticated: boolean;
   otpExpired: boolean;
   setStep: (step: number) => void;
@@ -16,38 +19,63 @@ interface AuthState {
   setTenantId: (tenantId: string) => void;
   setOtp: (otp: string) => void;
   setSessionToken: (token: string) => void;
+  setToken: (token: string) => void;
+  setUser: (user: string) => void;
   setAuthenticated: (auth: boolean) => void;
   setOtpExpired: (expired: boolean) => void;
+  logout: () => void;
   reset: () => void;
 }
 
-export const useAuthStore = create<AuthState>((set) => {
-  const initialState = {
-    step: 1,
-    username: "",
-    password: "",
-    tenantId: DEFAULT_TENANT_ID,
-    otp: "",
-    sessionToken: "",
-    isAuthenticated: false,
-    otpExpired: false,
-  };
+export const useAuthStore = create<AuthState>()(
+  persist(
+    (set) => {
+      const initialState = {
+        step: 1,
+        username: "",
+        password: "",
+        tenantId: DEFAULT_TENANT_ID,
+        otp: "",
+        sessionToken: "",
+        token: "",
+        user: "",
+        isAuthenticated: false,
+        otpExpired: false,
+      };
 
-  return {
-    ...initialState,
-
-    setStep: (step) => set({ step }),
-    setUsername: (username) => set({ username }),
-    setPassword: (password) => set({ password }),
-    setTenantId: (tenantId) => set({ tenantId }),
-    setOtp: (otp) => set({ otp }),
-    setSessionToken: (token) => set({ sessionToken: token }),
-    setAuthenticated: (auth) => set({ isAuthenticated: auth }),
-    setOtpExpired: (expired) => set({ otpExpired: expired }),
-
-    reset: () =>
-      set({
+      return {
         ...initialState,
+        setStep: (step) => set({ step }),
+        setUsername: (username) => set({ username }),
+        setPassword: (password) => set({ password }),
+        setTenantId: (tenantId) => set({ tenantId }),
+        setOtp: (otp) => set({ otp }),
+        setSessionToken: (token) => set({ sessionToken: token }),
+        setToken: (token) => set({ token }),
+        setUser: (user) => set({ user }),
+        setAuthenticated: (auth) => set({ isAuthenticated: auth }),
+        setOtpExpired: (expired) => set({ otpExpired: expired }),
+
+        logout: () => {
+          set({ ...initialState });
+          if (typeof window !== "undefined") {
+            localStorage.removeItem("auth-storage");
+          }
+        },
+
+        reset: () =>
+          set({
+            ...initialState,
+          }),
+      };
+    },
+    {
+      name: "auth-storage",
+      partialize: (state) => ({
+        token: state.token,
+        user: state.user,
+        isAuthenticated: state.isAuthenticated,
       }),
-  };
-});
+    }
+  )
+);

--- a/tests/persist.spec.ts
+++ b/tests/persist.spec.ts
@@ -1,0 +1,46 @@
+import { test, expect } from '@playwright/test';
+
+const storageKey = 'auth-storage';
+const loggedInState = {
+  state: {
+    token: 'valid-token',
+    user: 'admin',
+    isAuthenticated: true,
+  },
+  version: 0,
+};
+
+test('user stays logged in after refresh', async ({ page }) => {
+  await page.goto('/');
+  await page.evaluate(([k, v]) => localStorage.setItem(k, v), [storageKey, JSON.stringify(loggedInState)]);
+  await page.reload();
+  await expect(page.getByRole('button', { name: /logout/i })).toBeVisible();
+  await page.reload();
+  await expect(page.getByRole('button', { name: /logout/i })).toBeVisible();
+});
+
+test('logout clears state and prevents access on refresh', async ({ page }) => {
+  await page.goto('/');
+  await page.evaluate(([k, v]) => localStorage.setItem(k, v), [storageKey, JSON.stringify(loggedInState)]);
+  await page.reload();
+  await expect(page.getByRole('button', { name: /logout/i })).toBeVisible();
+  await page.getByRole('button', { name: /logout/i }).click();
+  await expect(page.getByText(/login to chodex/i)).toBeVisible();
+  await page.reload();
+  await expect(page.getByText(/login to chodex/i)).toBeVisible();
+});
+
+test('corrupted token redirects to login', async ({ page }) => {
+  const bad = { ...loggedInState, state: { ...loggedInState.state, token: '' } };
+  await page.goto('/');
+  await page.evaluate(([k, v]) => localStorage.setItem(k, v), [storageKey, JSON.stringify(bad)]);
+  await page.reload();
+  await expect(page.getByText(/login to chodex/i)).toBeVisible();
+});
+
+test('fresh load with no token shows login screen', async ({ page }) => {
+  await page.goto('/');
+  await page.evaluate((k) => localStorage.removeItem(k), storageKey);
+  await page.reload();
+  await expect(page.getByText(/login to chodex/i)).toBeVisible();
+});


### PR DESCRIPTION
## Summary
- persist auth state to `localStorage`
- store token/user on OTP verification
- logout uses new store method and clears saved auth
- main app checks for both `isAuthenticated` and `token`
- add Playwright tests for persisted login behaviour

## Testing
- `npm test` *(fails: vitest not found)*
- `npx playwright test` *(fails: could not download playwright)*

------
https://chatgpt.com/codex/tasks/task_e_685d4ce3fbf08328b33641fa71636cdc