### PR TITLE
Add refresh to applications page

### DIFF
--- a/src/components/pages/Applications.tsx
+++ b/src/components/pages/Applications.tsx
@@ -1,15 +1,16 @@
 import { useEffect } from "react";
 import { useApplicationStore } from "@/store/applicationStore";
 import ApplicationTable from "../applications/ApplicationTable";
+import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
-import { Package } from "lucide-react";
+import { Package, RefreshCw } from "lucide-react";
 
 export default function ApplicationsPage() {
-  const { applications, loading, fetchApplications } = useApplicationStore();
+  const { applications, loading, refreshApplications } = useApplicationStore();
 
   useEffect(() => {
-    fetchApplications();
-  }, [fetchApplications]);
+    refreshApplications();
+  }, [refreshApplications]);
 
   return (
     <div className="space-y-4">
@@ -18,8 +19,16 @@ export default function ApplicationsPage() {
         Applications
       </div>
       <Card>
-        <CardHeader>
+        <CardHeader className="flex flex-row items-center justify-between">
           <CardTitle>Registered Applications</CardTitle>
+          <Button
+            variant="outline"
+            size="sm"
+            onClick={refreshApplications}
+            disabled={loading}
+          >
+            <RefreshCw className="w-4 h-4" /> Refresh
+          </Button>
         </CardHeader>
         <CardContent>
           {loading ? <p>Loading...</p> : <ApplicationTable applications={applications} />}

--- a/src/store/applicationStore.test.ts
+++ b/src/store/applicationStore.test.ts
@@ -22,6 +22,7 @@ vi.mock('@/lib/api/application/service', () => ({
         },
       ],
     }),
+    refresh: vi.fn().mockResolvedValue({ data: null }),
   },
 }));
 
@@ -52,6 +53,14 @@ describe('useApplicationStore', () => {
 
   it('fetchApplications retrieves data', async () => {
     await useApplicationStore.getState().fetchApplications();
+    expect(ApplicationService.list).toHaveBeenCalledWith('tok', 'tenant1');
+    expect(useApplicationStore.getState().applications.length).toBe(1);
+    expect(useApplicationStore.getState().loading).toBe(false);
+  });
+
+  it('refreshApplications refreshes and lists data', async () => {
+    await useApplicationStore.getState().refreshApplications();
+    expect(ApplicationService.refresh).toHaveBeenCalledWith('tok', 'tenant1');
     expect(ApplicationService.list).toHaveBeenCalledWith('tok', 'tenant1');
     expect(useApplicationStore.getState().applications.length).toBe(1);
     expect(useApplicationStore.getState().loading).toBe(false);

--- a/src/store/applicationStore.ts
+++ b/src/store/applicationStore.ts
@@ -8,6 +8,7 @@ interface ApplicationState {
   loading: boolean;
   setApplications: (apps: Application[]) => void;
   fetchApplications: () => Promise<void>;
+  refreshApplications: () => Promise<void>;
 }
 
 export const useApplicationStore = create<ApplicationState>((set) => ({
@@ -18,6 +19,17 @@ export const useApplicationStore = create<ApplicationState>((set) => ({
     set({ loading: true });
     try {
       const { token, tenantId } = useAuthStore.getState();
+      const res = await ApplicationService.list(token, tenantId);
+      set({ applications: res.data });
+    } finally {
+      set({ loading: false });
+    }
+  },
+  refreshApplications: async () => {
+    set({ loading: true });
+    try {
+      const { token, tenantId } = useAuthStore.getState();
+      await ApplicationService.refresh(token, tenantId);
       const res = await ApplicationService.list(token, tenantId);
       set({ applications: res.data });
     } finally {


### PR DESCRIPTION
## Summary
- refresh applications on mount
- expose `refreshApplications` in the store and test it
- show a refresh button on Applications page

## Testing
- `npm test` *(fails: vitest not found)*
- `npm run lint` *(fails: cannot find @eslint/js)*

------
https://chatgpt.com/codex/tasks/task_e_685e3baf4de88328ba4023c894ae222c