### PR TITLE
Add refresh button and loading spinner

### DIFF
--- a/src/components/applications/ApplicationTable.tsx
+++ b/src/components/applications/ApplicationTable.tsx
@@ -9,7 +9,13 @@ interface Props {
 
 export default function ApplicationTable({ applications, loading }: Props) {
   if (!applications.length) {
-    return <p>No applications found.</p>;
+    return loading ? (
+      <div className="flex items-center justify-center py-8">
+        <Loader2 className="w-6 h-6 animate-spin text-muted-foreground" />
+      </div>
+    ) : (
+      <p>No applications found.</p>
+    );
   }
 
   return (

--- a/src/components/applications/ApplicationTable.tsx
+++ b/src/components/applications/ApplicationTable.tsx
@@ -1,11 +1,13 @@
 import type { Application } from "@/lib/api/models/application.model";
-import {Tooltip, TooltipContent, TooltipTrigger} from "@/components/ui/tooltip.tsx";
+import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip.tsx";
+import { Loader2 } from "lucide-react";
 
 interface Props {
   applications: Application[];
+  loading: boolean;
 }
 
-export default function ApplicationTable({ applications }: Props) {
+export default function ApplicationTable({ applications, loading }: Props) {
   if (!applications.length) {
     return <p>No applications found.</p>;
   }
@@ -43,19 +45,23 @@ export default function ApplicationTable({ applications }: Props) {
               </td>
               <td className="p-2">{new Date(app.lastChecked).toLocaleString()}</td>
               <td className="p-2 text-center">
-                <Tooltip>
-                  <TooltipTrigger>
-            <span
-                className={
-                    "inline-block w-3 h-3 rounded-full " +
-                    (app.isOnline ? "bg-green-500" : "bg-red-500")
-                }
-            />
-                  </TooltipTrigger>
-                  <TooltipContent>
-                    {app.isOnline ? "Online" : "Offline"}
-                  </TooltipContent>
-                </Tooltip>
+                {loading ? (
+                  <Loader2 className="w-3 h-3 animate-spin mx-auto text-muted-foreground" />
+                ) : (
+                  <Tooltip>
+                    <TooltipTrigger>
+                      <span
+                        className={
+                          "inline-block w-3 h-3 rounded-full " +
+                          (app.isOnline ? "bg-green-500" : "bg-red-500")
+                        }
+                      />
+                    </TooltipTrigger>
+                    <TooltipContent>
+                      {app.isOnline ? "Online" : "Offline"}
+                    </TooltipContent>
+                  </Tooltip>
+                )}
               </td>
             </tr>
         ))}

--- a/src/components/applications/ApplicationTable.tsx
+++ b/src/components/applications/ApplicationTable.tsx
@@ -1,6 +1,6 @@
 import type { Application } from "@/lib/api/models/application.model";
 import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip.tsx";
-import { Loader2 } from "lucide-react";
+import { Check, Loader2, X } from "lucide-react";
 
 interface Props {
   applications: Application[];
@@ -52,16 +52,15 @@ export default function ApplicationTable({ applications, loading }: Props) {
               <td className="p-2">{new Date(app.lastChecked).toLocaleString()}</td>
               <td className="p-2 text-center">
                 {loading ? (
-                  <Loader2 className="w-3 h-3 animate-spin mx-auto text-muted-foreground" />
+                  <Loader2 className="w-4 h-4 animate-spin mx-auto text-muted-foreground" />
                 ) : (
                   <Tooltip>
                     <TooltipTrigger>
-                      <span
-                        className={
-                          "inline-block w-3 h-3 rounded-full " +
-                          (app.isOnline ? "bg-green-500" : "bg-red-500")
-                        }
-                      />
+                      {app.isOnline ? (
+                        <Check className="w-4 h-4 text-green-500 mx-auto" />
+                      ) : (
+                        <X className="w-4 h-4 text-red-500 mx-auto" />
+                      )}
                     </TooltipTrigger>
                     <TooltipContent>
                       {app.isOnline ? "Online" : "Offline"}

--- a/src/components/auth/AuthForm.tsx
+++ b/src/components/auth/AuthForm.tsx
@@ -112,32 +112,26 @@ export default function AuthForm() {
       </div>
 
       {/* Tenant dropdown */}
-      <div className="relative w-full">
+      <div className="w-full space-y-3 my-[30px]">
         <label
           htmlFor="tenant"
-          className="absolute left-3 top-1 text-xs text-muted-foreground transition-all 
-      peer-placeholder-shown:top-[10px] 
-      peer-placeholder-shown:text-sm 
-      peer-placeholder-shown:text-gray-400 
-      peer-focus:top-1 
-      peer-focus:text-xs 
-      peer-focus:text-blue-500"
+          className="block text-sm font-medium text-muted-foreground mb-1 text-left"
         >
           Tenant
         </label>
 
         <Select value={tenantId} onValueChange={setTenantId}>
-          <SelectTrigger id="tenant" className="peer">
-            <SelectValue placeholder=" " />
+          <SelectTrigger id="tenant" className="w-full h-[44px] border border-input rounded-md px-3 text-sm shadow-sm focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-blue-500">
+            <SelectValue placeholder="Select a tenant" />
           </SelectTrigger>
           <SelectContent>
             <SelectItem value={DEFAULT_TENANT_ID}>Test Tenant</SelectItem>
-            <SelectItem value={DEFAULT_FAILED_TENANT_ID}>
-              Failed Tenant
-            </SelectItem>
+            <SelectItem value={DEFAULT_FAILED_TENANT_ID}>Failed Tenant</SelectItem>
           </SelectContent>
         </Select>
       </div>
+
+
 
       {/* Login button */}
       <Button

--- a/src/components/pages/Applications.tsx
+++ b/src/components/pages/Applications.tsx
@@ -18,7 +18,7 @@ import {
   SelectContent,
   SelectItem,
 } from "@/components/ui/select";
-import { Package, RefreshCw, Loader2 } from "lucide-react";
+import { Package, RefreshCw } from "lucide-react";
 import { ApplicationService } from "@/lib/api/application/service";
 
 export default function ApplicationsPage() {
@@ -122,11 +122,6 @@ export default function ApplicationsPage() {
           </div>
           <div className="relative">
             <ApplicationTable applications={visibleApps} loading={loading} />
-            {loading && applications.length > 0 && (
-              <div className="absolute inset-0 flex items-center justify-center bg-background/70">
-                <Loader2 className="w-6 h-6 animate-spin text-muted-foreground" />
-              </div>
-            )}
           </div>
         </CardContent>
       </Card>

--- a/src/components/pages/Applications.tsx
+++ b/src/components/pages/Applications.tsx
@@ -14,13 +14,18 @@ import { Package, RefreshCw, Loader2 } from "lucide-react";
 import { ApplicationService } from "@/lib/api/application/service";
 
 export default function ApplicationsPage() {
-  const { applications, loading, fetchApplications } = useApplicationStore();
+  const { applications, loading, fetchApplications, setLoading } = useApplicationStore();
   const { token, tenantId } = useAuthStore();
 
   const refresh = useCallback(async () => {
-    await ApplicationService.refresh(token, tenantId);
-    await fetchApplications();
-  }, [token, tenantId, fetchApplications]);
+    setLoading(true);
+    try {
+      await ApplicationService.refresh(token, tenantId);
+      await fetchApplications();
+    } finally {
+      setLoading(false);
+    }
+  }, [token, tenantId, fetchApplications, setLoading]);
 
   useEffect(() => {
     const load = async () => {

--- a/src/components/pages/Applications.tsx
+++ b/src/components/pages/Applications.tsx
@@ -1,15 +1,30 @@
-import { useEffect } from "react";
+import { useEffect, useCallback } from "react";
 import { useApplicationStore } from "@/store/applicationStore";
+import { useAuthStore } from "@/store/authStore";
 import ApplicationTable from "../applications/ApplicationTable";
-import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
-import { Package } from "lucide-react";
+import {
+  Card,
+  CardContent,
+  CardHeader,
+  CardTitle,
+  CardAction,
+} from "@/components/ui/card";
+import { Button } from "@/components/ui/button";
+import { Package, RefreshCw } from "lucide-react";
+import { ApplicationService } from "@/lib/api/application/service";
 
 export default function ApplicationsPage() {
   const { applications, loading, fetchApplications } = useApplicationStore();
+  const { token, tenantId } = useAuthStore();
+
+  const refresh = useCallback(async () => {
+    await ApplicationService.refresh(token, tenantId);
+    await fetchApplications();
+  }, [token, tenantId, fetchApplications]);
 
   useEffect(() => {
-    fetchApplications();
-  }, [fetchApplications]);
+    refresh();
+  }, [refresh]);
 
   return (
     <div className="space-y-4">
@@ -18,11 +33,16 @@ export default function ApplicationsPage() {
         Applications
       </div>
       <Card>
-        <CardHeader>
+        <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
           <CardTitle>Registered Applications</CardTitle>
+          <CardAction>
+            <Button size="icon" variant="outline" onClick={refresh}>
+              <RefreshCw className="w-4 h-4" />
+            </Button>
+          </CardAction>
         </CardHeader>
         <CardContent>
-          {loading ? <p>Loading...</p> : <ApplicationTable applications={applications} />}
+          <ApplicationTable applications={applications} loading={loading} />
         </CardContent>
       </Card>
     </div>

--- a/src/components/pages/Applications.tsx
+++ b/src/components/pages/Applications.tsx
@@ -10,7 +10,7 @@ import {
   CardAction,
 } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
-import { Package, RefreshCw } from "lucide-react";
+import { Package, RefreshCw, Loader2 } from "lucide-react";
 import { ApplicationService } from "@/lib/api/application/service";
 
 export default function ApplicationsPage() {
@@ -23,8 +23,12 @@ export default function ApplicationsPage() {
   }, [token, tenantId, fetchApplications]);
 
   useEffect(() => {
-    refresh();
-  }, [refresh]);
+    const load = async () => {
+      await fetchApplications();
+      await refresh();
+    };
+    load();
+  }, [fetchApplications, refresh]);
 
   return (
     <div className="space-y-4">
@@ -36,13 +40,20 @@ export default function ApplicationsPage() {
         <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
           <CardTitle>Registered Applications</CardTitle>
           <CardAction>
-            <Button size="icon" variant="outline" onClick={refresh}>
+            <Button size="icon" variant="outline" onClick={refresh} disabled={loading}>
               <RefreshCw className="w-4 h-4" />
             </Button>
           </CardAction>
         </CardHeader>
         <CardContent>
-          <ApplicationTable applications={applications} loading={loading} />
+          <div className="relative">
+            <ApplicationTable applications={applications} loading={loading} />
+            {loading && applications.length > 0 && (
+              <div className="absolute inset-0 flex items-center justify-center bg-background/70">
+                <Loader2 className="w-6 h-6 animate-spin text-muted-foreground" />
+              </div>
+            )}
+          </div>
         </CardContent>
       </Card>
     </div>

--- a/src/components/ui/select.tsx
+++ b/src/components/ui/select.tsx
@@ -1,25 +1,25 @@
-import * as React from "react";
-import * as SelectPrimitive from "@radix-ui/react-select";
-import { CheckIcon, ChevronDownIcon, ChevronUpIcon } from "lucide-react";
+import * as React from "react"
+import * as SelectPrimitive from "@radix-ui/react-select"
+import { CheckIcon, ChevronDownIcon, ChevronUpIcon } from "lucide-react"
 
-import { cn } from "@/lib/utils";
+import { cn } from "@/lib/utils"
 
 function Select({
   ...props
 }: React.ComponentProps<typeof SelectPrimitive.Root>) {
-  return <SelectPrimitive.Root data-slot="select" {...props} />;
+  return <SelectPrimitive.Root data-slot="select" {...props} />
 }
 
 function SelectGroup({
   ...props
 }: React.ComponentProps<typeof SelectPrimitive.Group>) {
-  return <SelectPrimitive.Group data-slot="select-group" {...props} />;
+  return <SelectPrimitive.Group data-slot="select-group" {...props} />
 }
 
 function SelectValue({
   ...props
 }: React.ComponentProps<typeof SelectPrimitive.Value>) {
-  return <SelectPrimitive.Value data-slot="select-value" {...props} />;
+  return <SelectPrimitive.Value data-slot="select-value" {...props} />
 }
 
 function SelectTrigger({
@@ -28,24 +28,14 @@ function SelectTrigger({
   children,
   ...props
 }: React.ComponentProps<typeof SelectPrimitive.Trigger> & {
-  size?: "sm" | "default";
+  size?: "sm" | "default"
 }) {
   return (
     <SelectPrimitive.Trigger
       data-slot="select-trigger"
       data-size={size}
       className={cn(
-        // 🔽 override size to match input field
-        "h-[44px] pt-4 px-3 text-sm",
-        // 🔽 input-like styling
-        "flex w-full items-center justify-between gap-2 rounded-md border border-input bg-background shadow-sm transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 focus-visible:ring-offset-2",
-        // 🔽 clean placeholder support
-        "data-[placeholder]:text-gray-400",
-        // 🔽 clean disabled/focus
-        "disabled:cursor-not-allowed disabled:opacity-50",
-        // 🔽 icon + value spacing
-        "*:data-[slot=select-value]:flex *:data-[slot=select-value]:items-center *:data-[slot=select-value]:gap-2",
-        "[&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
+        "border-input data-[placeholder]:text-muted-foreground [&_svg:not([class*='text-'])]:text-muted-foreground focus-visible:border-ring focus-visible:ring-ring/50 aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive dark:bg-input/30 dark:hover:bg-input/50 flex w-fit items-center justify-between gap-2 rounded-md border bg-transparent px-3 py-2 text-sm whitespace-nowrap shadow-xs transition-[color,box-shadow] outline-none focus-visible:ring-[3px] disabled:cursor-not-allowed disabled:opacity-50 data-[size=default]:h-9 data-[size=sm]:h-8 *:data-[slot=select-value]:line-clamp-1 *:data-[slot=select-value]:flex *:data-[slot=select-value]:items-center *:data-[slot=select-value]:gap-2 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
         className
       )}
       {...props}
@@ -55,7 +45,7 @@ function SelectTrigger({
         <ChevronDownIcon className="size-4 opacity-50" />
       </SelectPrimitive.Icon>
     </SelectPrimitive.Trigger>
-  );
+  )
 }
 
 function SelectContent({
@@ -90,7 +80,7 @@ function SelectContent({
         <SelectScrollDownButton />
       </SelectPrimitive.Content>
     </SelectPrimitive.Portal>
-  );
+  )
 }
 
 function SelectLabel({
@@ -103,7 +93,7 @@ function SelectLabel({
       className={cn("text-muted-foreground px-2 py-1.5 text-xs", className)}
       {...props}
     />
-  );
+  )
 }
 
 function SelectItem({
@@ -127,7 +117,7 @@ function SelectItem({
       </span>
       <SelectPrimitive.ItemText>{children}</SelectPrimitive.ItemText>
     </SelectPrimitive.Item>
-  );
+  )
 }
 
 function SelectSeparator({
@@ -140,7 +130,7 @@ function SelectSeparator({
       className={cn("bg-border pointer-events-none -mx-1 my-1 h-px", className)}
       {...props}
     />
-  );
+  )
 }
 
 function SelectScrollUpButton({
@@ -158,7 +148,7 @@ function SelectScrollUpButton({
     >
       <ChevronUpIcon className="size-4" />
     </SelectPrimitive.ScrollUpButton>
-  );
+  )
 }
 
 function SelectScrollDownButton({
@@ -176,7 +166,7 @@ function SelectScrollDownButton({
     >
       <ChevronDownIcon className="size-4" />
     </SelectPrimitive.ScrollDownButton>
-  );
+  )
 }
 
 export {
@@ -190,4 +180,4 @@ export {
   SelectSeparator,
   SelectTrigger,
   SelectValue,
-};
+}

--- a/src/store/applicationStore.test.ts
+++ b/src/store/applicationStore.test.ts
@@ -56,4 +56,9 @@ describe('useApplicationStore', () => {
     expect(useApplicationStore.getState().applications.length).toBe(1);
     expect(useApplicationStore.getState().loading).toBe(false);
   });
+
+  it('setLoading updates loading state', () => {
+    useApplicationStore.getState().setLoading(true);
+    expect(useApplicationStore.getState().loading).toBe(true);
+  });
 });

--- a/src/store/applicationStore.ts
+++ b/src/store/applicationStore.ts
@@ -7,6 +7,7 @@ interface ApplicationState {
   applications: Application[];
   loading: boolean;
   setApplications: (apps: Application[]) => void;
+  setLoading: (loading: boolean) => void;
   fetchApplications: () => Promise<void>;
 }
 
@@ -14,6 +15,7 @@ export const useApplicationStore = create<ApplicationState>((set) => ({
   applications: [],
   loading: false,
   setApplications: (apps) => set({ applications: apps }),
+  setLoading: (loading) => set({ loading }),
   fetchApplications: async () => {
     set({ loading: true });
     try {


### PR DESCRIPTION
## Summary
- add an application refresh button
- refresh endpoints are called on page load
- show table while refreshing and animate status cells

## Testing
- `npm test` *(fails: vitest not found)*
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run test:e2e` *(fails: playwright not found)*

------
https://chatgpt.com/codex/tasks/task_e_685e3da8cec88328a72044380d010fd2