### PR TITLE
Add application CRUD UI

### DIFF
--- a/src/components/applications/ApplicationForm.tsx
+++ b/src/components/applications/ApplicationForm.tsx
@@ -1,0 +1,114 @@
+import { useForm } from "react-hook-form";
+import { z } from "zod";
+import { zodResolver } from "@hookform/resolvers/zod";
+import type { Application } from "@/lib/api/models/application.model";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Form, FormField, FormItem, FormLabel, FormControl, FormMessage } from "@/components/ui/form";
+
+const schema = z.object({
+  id: z.string().uuid({ message: "Id is required" }),
+  name: z.string().min(1, "Name is required"),
+  code: z.string().min(1, "Code is required"),
+  basePath: z.string().min(1, "Base path is required"),
+  url: z.string().url("Invalid URL"),
+  description: z.string().optional(),
+  isOnline: z.boolean(),
+  lastChecked: z.string(),
+  version: z.string().optional().nullable(),
+  tags: z.string().optional().nullable(),
+  owner: z.string().optional().nullable(),
+});
+
+export type ApplicationFormData = z.infer<typeof schema>;
+
+interface Props {
+  defaultValues: ApplicationFormData;
+  onSubmit: (data: ApplicationFormData) => void;
+  submitLabel?: string;
+}
+
+export default function ApplicationForm({ defaultValues, onSubmit, submitLabel = "Save" }: Props) {
+  const form = useForm<ApplicationFormData>({
+    resolver: zodResolver(schema),
+    defaultValues,
+  });
+
+  return (
+    <Form {...form}>
+      <form
+        onSubmit={form.handleSubmit(onSubmit)}
+        className="space-y-4"
+      >
+        <FormField
+          control={form.control}
+          name="name"
+          render={({ field }) => (
+            <FormItem>
+              <FormLabel>Name</FormLabel>
+              <FormControl>
+                <Input {...field} />
+              </FormControl>
+              <FormMessage />
+            </FormItem>
+          )}
+        />
+        <FormField
+          control={form.control}
+          name="code"
+          render={({ field }) => (
+            <FormItem>
+              <FormLabel>Code</FormLabel>
+              <FormControl>
+                <Input {...field} />
+              </FormControl>
+              <FormMessage />
+            </FormItem>
+          )}
+        />
+        <FormField
+          control={form.control}
+          name="basePath"
+          render={({ field }) => (
+            <FormItem>
+              <FormLabel>Base Path</FormLabel>
+              <FormControl>
+                <Input {...field} />
+              </FormControl>
+              <FormMessage />
+            </FormItem>
+          )}
+        />
+        <FormField
+          control={form.control}
+          name="url"
+          render={({ field }) => (
+            <FormItem>
+              <FormLabel>URL</FormLabel>
+              <FormControl>
+                <Input {...field} />
+              </FormControl>
+              <FormMessage />
+            </FormItem>
+          )}
+        />
+        <FormField
+          control={form.control}
+          name="description"
+          render={({ field }) => (
+            <FormItem>
+              <FormLabel>Description</FormLabel>
+              <FormControl>
+                <Input {...field} />
+              </FormControl>
+              <FormMessage />
+            </FormItem>
+          )}
+        />
+        <div className="flex justify-end">
+          <Button type="submit">{submitLabel}</Button>
+        </div>
+      </form>
+    </Form>
+  );
+}

--- a/src/components/applications/ApplicationTable.tsx
+++ b/src/components/applications/ApplicationTable.tsx
@@ -1,13 +1,19 @@
 import type { Application } from "@/lib/api/models/application.model";
 import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip.tsx";
-import { Check, Loader2, X } from "lucide-react";
+import { Check, Loader2, X, Pencil, Trash } from "lucide-react";
+import { Button } from "@/components/ui/button";
 
-interface Props {
+interface ActionProps {
+  onEdit: (app: Application) => void;
+  onDelete: (app: Application) => void;
+}
+
+interface Props extends ActionProps {
   applications: Application[];
   loading: boolean;
 }
 
-export default function ApplicationTable({ applications, loading }: Props) {
+export default function ApplicationTable({ applications, loading, onEdit, onDelete }: Props) {
   if (!applications.length) {
     return loading ? (
       <div className="flex items-center justify-center py-8">
@@ -30,6 +36,7 @@ export default function ApplicationTable({ applications, loading }: Props) {
           <th className="p-2 text-left font-semibold">URL</th>
           <th className="p-2 text-left font-semibold">Last Checked</th>
           <th className="p-2 font-semibold text-center w-[20px]">Status</th>
+          <th className="p-2 font-semibold text-center w-[60px]">Actions</th>
         </tr>
         </thead>
         <tbody>
@@ -67,6 +74,14 @@ export default function ApplicationTable({ applications, loading }: Props) {
                     </TooltipContent>
                   </Tooltip>
                 )}
+              </td>
+              <td className="p-2 text-center space-x-1 whitespace-nowrap">
+                <Button size="icon" variant="ghost" onClick={() => onEdit(app)}>
+                  <Pencil className="w-4 h-4" />
+                </Button>
+                <Button size="icon" variant="ghost" onClick={() => onDelete(app)}>
+                  <Trash className="w-4 h-4" />
+                </Button>
               </td>
             </tr>
         ))}

--- a/src/lib/api/application/endpoints.ts
+++ b/src/lib/api/application/endpoints.ts
@@ -3,6 +3,7 @@ import { APPLICATION_API_BASE_URL } from "../index";
 export const ApplicationEndpoints = {
   list: `${APPLICATION_API_BASE_URL}/application`,
   create: `${APPLICATION_API_BASE_URL}/application`,
+  update: (id: string) => `${APPLICATION_API_BASE_URL}/application/${id}`,
   refresh: `${APPLICATION_API_BASE_URL}/application/refresh`,
   delete: (id: string) => `${APPLICATION_API_BASE_URL}/application/${id}`,
 };

--- a/src/lib/api/application/service.ts
+++ b/src/lib/api/application/service.ts
@@ -3,7 +3,7 @@ import { ApplicationEndpoints } from "./endpoints";
 import { createAuthConfig } from "../helpers";
 import type { ApiResponse } from "../models/api-response.model";
 import type { Application } from "../models/application.model";
-import type { ApplicationCreateRequest } from "../models/application-create-request.model";
+import type { ApplicationSaveRequest } from "../models/application-save-request.model";
 
 export const ApplicationService = {
   list: async (
@@ -18,12 +18,26 @@ export const ApplicationService = {
   },
 
   create: async (
-    data: ApplicationCreateRequest,
+    data: ApplicationSaveRequest,
     token: string,
     tenantId: string
   ): Promise<ApiResponse<Application>> => {
     const response = await axios.post(
       ApplicationEndpoints.create,
+      data,
+      createAuthConfig(token, tenantId)
+    );
+    return response.data;
+  },
+
+  update: async (
+    id: string,
+    data: ApplicationSaveRequest,
+    token: string,
+    tenantId: string
+  ): Promise<ApiResponse<Application>> => {
+    const response = await axios.put(
+      ApplicationEndpoints.update(id),
       data,
       createAuthConfig(token, tenantId)
     );

--- a/src/lib/api/index.ts
+++ b/src/lib/api/index.ts
@@ -4,4 +4,4 @@ export const APPLICATION_API_BASE_URL = "https://localhost:5091/api";
 export const DEFAULT_TENANT_ID = "11111111-1111-1111-1111-111111111111";
 export const DEFAULT_FAILED_TENANT_ID = "11111111-1111-1111-1111-111111111112";
 export { createAuthConfig, createAuthHeaders } from "./helpers";
-export type { ApplicationCreateRequest } from "./models/application-create-request.model";
+export type { ApplicationSaveRequest } from "./models/application-save-request.model";

--- a/src/lib/api/models/application-save-request.model.ts
+++ b/src/lib/api/models/application-save-request.model.ts
@@ -1,0 +1,13 @@
+export interface ApplicationSaveRequest {
+  id: string;
+  name: string;
+  code: string;
+  basePath: string;
+  url: string;
+  description?: string | null;
+  isOnline: boolean;
+  lastChecked: string;
+  version?: string | null;
+  tags?: string | null;
+  owner?: string | null;
+}

--- a/src/store/applicationStore.test.ts
+++ b/src/store/applicationStore.test.ts
@@ -3,6 +3,20 @@ import { useApplicationStore } from './applicationStore';
 import { useAuthStore } from './authStore';
 import { ApplicationService } from '@/lib/api/application/service';
 
+const sample = {
+  id: '2',
+  name: 'Another',
+  code: 'another',
+  basePath: '/another',
+  url: 'http://another',
+  description: '',
+  isOnline: true,
+  lastChecked: '',
+  version: null,
+  tags: null,
+  owner: null,
+};
+
 vi.mock('@/lib/api/application/service', () => ({
   ApplicationService: {
     list: vi.fn().mockResolvedValue({
@@ -22,22 +36,12 @@ vi.mock('@/lib/api/application/service', () => ({
         },
       ],
     }),
+    create: vi.fn().mockResolvedValue({ data: sample }),
+    update: vi.fn().mockResolvedValue({ data: sample }),
+    delete: vi.fn().mockResolvedValue({ data: null }),
   },
 }));
 
-const sample = {
-  id: '2',
-  name: 'Another',
-  code: 'another',
-  basePath: '/another',
-  url: 'http://another',
-  description: '',
-  isOnline: true,
-  lastChecked: '',
-  version: null,
-  tags: null,
-  owner: null,
-};
 
 describe('useApplicationStore', () => {
   beforeEach(() => {
@@ -60,5 +64,23 @@ describe('useApplicationStore', () => {
   it('setLoading updates loading state', () => {
     useApplicationStore.getState().setLoading(true);
     expect(useApplicationStore.getState().loading).toBe(true);
+  });
+
+  it('createApplication posts data and refreshes list', async () => {
+    await useApplicationStore.getState().createApplication(sample as any);
+    expect(ApplicationService.create).toHaveBeenCalledWith(sample, 'tok', 'tenant1');
+    expect(ApplicationService.list).toHaveBeenCalledTimes(2);
+  });
+
+  it('updateApplication puts data and refreshes list', async () => {
+    await useApplicationStore.getState().updateApplication(sample as any);
+    expect(ApplicationService.update).toHaveBeenCalledWith(sample.id, sample, 'tok', 'tenant1');
+    expect(ApplicationService.list).toHaveBeenCalledTimes(3);
+  });
+
+  it('deleteApplication deletes and refreshes list', async () => {
+    await useApplicationStore.getState().deleteApplication('2');
+    expect(ApplicationService.delete).toHaveBeenCalledWith('2', 'tok', 'tenant1');
+    expect(ApplicationService.list).toHaveBeenCalledTimes(4);
   });
 });

--- a/src/store/applicationStore.ts
+++ b/src/store/applicationStore.ts
@@ -9,6 +9,9 @@ interface ApplicationState {
   setApplications: (apps: Application[]) => void;
   setLoading: (loading: boolean) => void;
   fetchApplications: () => Promise<void>;
+  createApplication: (app: Application) => Promise<void>;
+  updateApplication: (app: Application) => Promise<void>;
+  deleteApplication: (id: string) => Promise<void>;
 }
 
 export const useApplicationStore = create<ApplicationState>((set) => ({
@@ -25,5 +28,20 @@ export const useApplicationStore = create<ApplicationState>((set) => ({
     } finally {
       set({ loading: false });
     }
+  },
+  createApplication: async (app) => {
+    const { token, tenantId } = useAuthStore.getState();
+    await ApplicationService.create(app, token, tenantId);
+    await useApplicationStore.getState().fetchApplications();
+  },
+  updateApplication: async (app) => {
+    const { token, tenantId } = useAuthStore.getState();
+    await ApplicationService.update(app.id, app, token, tenantId);
+    await useApplicationStore.getState().fetchApplications();
+  },
+  deleteApplication: async (id) => {
+    const { token, tenantId } = useAuthStore.getState();
+    await ApplicationService.delete(id, token, tenantId);
+    await useApplicationStore.getState().fetchApplications();
   },
 }));


### PR DESCRIPTION
## Summary
- add ApplicationForm for create/update
- expand ApplicationTable with edit & delete buttons
- wire up form in Applications page
- add endpoints and service functions for update
- update application store with create/update/delete actions
- add corresponding unit tests

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6862083d89ec8328807fa7d3bc2ed3ca