### PR TITLE
Add Excel reader page

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16,6 +16,7 @@
         "@radix-ui/react-radio-group": "^1.3.7",
         "@radix-ui/react-select": "^2.2.5",
         "@radix-ui/react-slot": "^1.2.3",
+        "@radix-ui/react-tabs": "^1.1.12",
         "@radix-ui/react-toggle": "^1.1.9",
         "@radix-ui/react-toggle-group": "^1.1.10",
         "@radix-ui/react-tooltip": "^1.2.7",
@@ -34,11 +35,11 @@
         "react-router-dom": "^6.23.1",
         "recharts": "^2.9.2",
         "sonner": "^2.0.5",
+        "tabulator-tables": "^5.5.4",
         "tailwind-merge": "^3.3.1",
         "tailwind-variants": "^1.0.0",
         "zod": "^3.25.67",
-        "zustand": "^5.0.5",
-        "tabulator-tables": "^5.5.4"
+        "zustand": "^5.0.5"
       },
       "devDependencies": {
         "@eslint/js": "^9.25.0",
@@ -1753,6 +1754,36 @@
       },
       "peerDependenciesMeta": {
         "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-tabs": {
+      "version": "1.1.12",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-tabs/-/react-tabs-1.1.12.tgz",
+      "integrity": "sha512-GTVAlRVrQrSw3cEARM0nAx73ixrWDPNZAruETn3oHCNP6SbZ/hNxdxp+u7VkIEv3/sFoLq1PfcHrl7Pnp0CDpw==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.2",
+        "@radix-ui/react-context": "1.1.2",
+        "@radix-ui/react-direction": "1.1.1",
+        "@radix-ui/react-id": "1.1.1",
+        "@radix-ui/react-presence": "1.1.4",
+        "@radix-ui/react-primitive": "2.1.3",
+        "@radix-ui/react-roving-focus": "1.1.10",
+        "@radix-ui/react-use-controllable-state": "1.2.2"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
           "optional": true
         }
       }
@@ -5913,6 +5944,11 @@
         "node": ">=8"
       }
     },
+    "node_modules/tabulator-tables": {
+      "version": "5.5.4",
+      "resolved": "https://registry.npmjs.org/tabulator-tables/-/tabulator-tables-5.5.4.tgz",
+      "license": "MIT"
+    },
     "node_modules/tailwind-merge": {
       "version": "3.3.1",
       "resolved": "https://registry.npmjs.org/tailwind-merge/-/tailwind-merge-3.3.1.tgz",
@@ -6605,12 +6641,6 @@
           "optional": true
         }
       }
-    },
-    "node_modules/tabulator-tables": {
-      "version": "5.5.4",
-      "resolved": "https://registry.npmjs.org/tabulator-tables/-/tabulator-tables-5.5.4.tgz",
-      "integrity": "",
-      "license": "MIT"
     }
   }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -37,7 +37,8 @@
         "tailwind-merge": "^3.3.1",
         "tailwind-variants": "^1.0.0",
         "zod": "^3.25.67",
-        "zustand": "^5.0.5"
+        "zustand": "^5.0.5",
+        "tabulator-tables": "^5.5.4"
       },
       "devDependencies": {
         "@eslint/js": "^9.25.0",
@@ -6604,6 +6605,12 @@
           "optional": true
         }
       }
+    },
+    "node_modules/tabulator-tables": {
+      "version": "5.5.4",
+      "resolved": "https://registry.npmjs.org/tabulator-tables/-/tabulator-tables-5.5.4.tgz",
+      "integrity": "",
+      "license": "MIT"
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "@radix-ui/react-radio-group": "^1.3.7",
     "@radix-ui/react-select": "^2.2.5",
     "@radix-ui/react-slot": "^1.2.3",
+    "@radix-ui/react-tabs": "^1.1.12",
     "@radix-ui/react-toggle": "^1.1.9",
     "@radix-ui/react-toggle-group": "^1.1.10",
     "@radix-ui/react-tooltip": "^1.2.7",

--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
     "react-router-dom": "^6.23.1",
     "recharts": "^2.9.2",
     "sonner": "^2.0.5",
+    "tabulator-tables": "^5.5.4",
     "tailwind-merge": "^3.3.1",
     "tailwind-variants": "^1.0.0",
     "zod": "^3.25.67",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -6,6 +6,7 @@ import ProfilePage from "./components/pages/Profile";
 import SettingsPage from "./components/pages/Settings";
 import ApplicationsPage from "./components/pages/Applications";
 import FileManagerPage from "./components/pages/FileManager";
+import ExcelReaderPage from "./components/pages/ExcelReader";
 import { useEffect } from "react";
 import { Routes, Route, Navigate } from "react-router-dom";
 
@@ -25,6 +26,7 @@ export default function App() {
         <Route index element={<HomePage />} />
         <Route path="profile" element={<ProfilePage />} />
         <Route path="settings" element={<SettingsPage />} />
+        <Route path="excel" element={<ExcelReaderPage />} />
         <Route path="applications" element={<ApplicationsPage />} />
         <Route path="files" element={<FileManagerPage />} />
         <Route path="*" element={<Navigate to="/" />} />

--- a/src/components/layout/AuthenticatedLayout.tsx
+++ b/src/components/layout/AuthenticatedLayout.tsx
@@ -11,6 +11,7 @@ import {
   Settings as SettingsIcon,
   Package,
   Folder,
+  FileSpreadsheet,
   User,
 } from "lucide-react";
 import { Avatar, AvatarFallback } from "@/components/ui/avatar";
@@ -99,6 +100,20 @@ export default function AuthenticatedLayout() {
         >
           <Folder className="w-4 h-4" />
           {!collapsed && <span>Files</span>}
+        </NavLink>
+        <NavLink
+          to="/excel"
+          className={({ isActive }) =>
+            cn(
+              "flex items-center gap-2 rounded-md p-2 text-sm hover:bg-accent",
+              collapsed ? "justify-center" : "",
+              isActive && "bg-accent"
+            )
+          }
+          onClick={() => setSidebarOpen(false)}
+        >
+          <FileSpreadsheet className="w-4 h-4" />
+          {!collapsed && <span>Excel</span>}
         </NavLink>
         <NavLink
           to="/settings"

--- a/src/components/pages/ExcelReader.tsx
+++ b/src/components/pages/ExcelReader.tsx
@@ -1,5 +1,5 @@
 import { useState, useRef, useEffect } from 'react';
-import Tabulator from 'tabulator-tables';
+import { TabulatorFull as Tabulator } from 'tabulator-tables';
 import 'tabulator-tables/dist/css/tabulator.min.css';
 import { Upload, Loader2, FileSpreadsheet } from 'lucide-react';
 import { Button } from '@/components/ui/button';

--- a/src/components/pages/ExcelReader.tsx
+++ b/src/components/pages/ExcelReader.tsx
@@ -22,8 +22,9 @@ export default function ExcelReaderPage() {
     workbook.sheets.forEach((sheet) => {
       const container = tableContainers.current[sheet.sheetName];
       if (!container) return;
-      if (tables.current[sheet.sheetName]) {
-        tables.current[sheet.sheetName].destroy();
+      const existing = tables.current[sheet.sheetName];
+      if (existing?.destroy) {
+        existing.destroy();
       }
       const data = sheet.rows.map((row) => {
         const obj: Record<string, string | number | null> = {};

--- a/src/components/pages/ExcelReader.tsx
+++ b/src/components/pages/ExcelReader.tsx
@@ -1,56 +1,225 @@
-import { useState, useRef, useLayoutEffect } from "react";
+import { useState, useRef, useEffect } from "react";
 import { TabulatorFull as Tabulator } from "tabulator-tables";
 import "tabulator-tables/dist/css/tabulator.min.css";
-import { Upload, Loader2, FileSpreadsheet } from 'lucide-react';
+import { FileSpreadsheet } from 'lucide-react';
 import { Button } from '@/components/ui/button';
 import { Card, CardHeader, CardTitle, CardContent } from '@/components/ui/card';
 import { Input } from '@/components/ui/input';
 import { useExcelStore } from '@/store/excelStore';
+import type { ExcelWorkbook, ExcelSheet, ExcelColumn } from '@/lib/api/models/excel-workbook.model';
+import { toast } from "sonner";
+import { Tabs, TabsList, TabsTrigger, TabsContent } from "@/components/ui/tabs";
+import { Dialog, DialogTrigger, DialogContent, DialogHeader, DialogTitle, DialogFooter } from '@/components/ui/dialog';
+import { Input as ShadInput } from '@/components/ui/input';
 
 export default function ExcelReaderPage() {
   const { workbook, loading, readExcel } = useExcelStore();
   const [file, setFile] = useState<File | null>(null);
-  const tableContainers = useRef<Record<string, HTMLDivElement | null>>({});
-  interface TabulatorInstance {
-    destroy?: () => void;
-  }
-  const tables = useRef<Record<string, TabulatorInstance>>({});
+  const [activeSheet, setActiveSheet] = useState<string | null>(null);
+  const [showFiltered, setShowFiltered] = useState(false);
+  // Store Tabulator instances for cleanup
+  const tables = useRef<Record<string, object>>({});
 
-  useLayoutEffect(() => {
-    if (!workbook) return;
+  // Cleanup Tabulator tables on unmount or when workbook changes
+  useEffect(() => {
+    Object.values(tables.current).forEach((t) => (t as any)?.destroy && (t as any).destroy());
+    tables.current = {};
+  }, [workbook]);
 
-    workbook.sheets.forEach((sheet) => {
-      const container = tableContainers.current[sheet.sheetName];
-      if (!container) return;
-      const existing = tables.current[sheet.sheetName];
-      if (existing?.destroy) {
-        existing.destroy();
+  const handleSubmit = async () => {
+    if (!file) {
+      toast.error("Please select a file to upload.");
+      return;
+    }
+    try {
+      const result = await readExcel(file);
+      console.log("[ExcelReader] readExcel result:", result);
+      if (!result || !result.sheets || result.sheets.length === 0) {
+        toast.warning("No data found in the uploaded Excel file.");
+      } else {
+        toast.success("Excel file loaded successfully.");
       }
-      const data = sheet.rows.map((row) => {
+    } catch (err: any) {
+      toast.error("Failed to read Excel file.");
+    }
+    setFile(null);
+  };
+
+  // Utility: Remove blank rows based on required column keys
+  function removeBlankRows(
+    rows: (string | number | null)[][],
+    columns: ExcelColumn[],
+    requiredKeys: string[]
+  ): (string | number | null)[][] {
+    const keyIndexes = requiredKeys.map(
+      (key) => columns.findIndex((col) => col.name === key)
+    );
+    // Only consider a row blank if ALL required keys are blank
+    return rows.filter((row) =>
+      keyIndexes.some((idx) => {
+        const val = row[idx];
+        return val !== undefined && val !== null && String(val).trim() !== "";
+      })
+    );
+  }
+
+  // Remove blank rows from the actual sheet data (permanently) when button is clicked
+  const handleRemoveRows = (sheetName: string) => {
+    if (!workbook) return;
+    const updatedSheets = workbook.sheets.map((sheet) => {
+      if (sheet.sheetName !== sheetName) return sheet;
+      return {
+        ...sheet,
+        rows: removeBlankRows(sheet.rows, sheet.columns, sheet.columns.map((c) => c.name)),
+      };
+    });
+    // Update the workbook in the store
+    useExcelStore.getState().setWorkbook({ ...workbook, sheets: updatedSheets });
+  };
+
+  // Remove a specific row by index from a sheet
+  const handleDeleteRow = (sheetName: string, rowIdx: number) => {
+    if (!workbook) return;
+    const updatedSheets = workbook.sheets.map((sheet) => {
+      if (sheet.sheetName !== sheetName) return sheet;
+      return {
+        ...sheet,
+        rows: sheet.rows.filter((_, idx) => idx !== rowIdx),
+      };
+    });
+    useExcelStore.getState().setWorkbook({ ...workbook, sheets: updatedSheets });
+  };
+
+  // Use a specific row as header and remove all rows up to and including it
+  const handleUseRowAsHeader = (sheetName: string, rowIdx: number) => {
+    if (!workbook) return;
+    const updatedSheets = workbook.sheets.map((sheet) => {
+      if (sheet.sheetName !== sheetName) return sheet;
+      const newHeaderRow = sheet.rows[rowIdx];
+      if (!newHeaderRow) return sheet;
+      // Build new columns, preserving previous column properties if possible
+      const newColumns: ExcelColumn[] = newHeaderRow.map((col, i) => {
+        const prevCol = sheet.columns[i];
+        return {
+          name: String(col ?? `Column${i + 1}`),
+          dataType: prevCol?.dataType ?? 'string',
+          format: prevCol?.format ?? '',
+          formula: prevCol?.formula ?? '',
+        };
+      });
+      const newRows = sheet.rows.slice(rowIdx + 1);
+      return {
+        ...sheet,
+        columns: newColumns,
+        rows: newRows,
+      };
+    });
+    useExcelStore.getState().setWorkbook({ ...workbook, sheets: updatedSheets });
+  };
+
+  // State for rename dialog
+  const [renameDialogOpen, setRenameDialogOpen] = useState(false);
+  const [renameSheet, setRenameSheet] = useState<string | null>(null);
+  const [renameColIdx, setRenameColIdx] = useState<number | null>(null);
+  const [renameCurrent, setRenameCurrent] = useState('');
+  const [renameValue, setRenameValue] = useState('');
+
+  // Handler to open dialog
+  const openRenameDialog = (sheetName: string, colIdx: number, currentName: string) => {
+    setRenameSheet(sheetName);
+    setRenameColIdx(colIdx);
+    setRenameCurrent(currentName);
+    setRenameValue(currentName);
+    setRenameDialogOpen(true);
+  };
+  // Handler to confirm rename
+  const handleRenameConfirm = () => {
+    if (renameSheet && renameColIdx !== null && renameValue.trim() && renameValue !== renameCurrent) {
+      useExcelStore.getState().renameColumn(renameSheet, renameColIdx, renameValue.trim());
+    }
+    setRenameDialogOpen(false);
+  };
+
+  // Callback ref to initialize Tabulator when container is mounted
+  const getTableRef = (sheet: ExcelSheet, filtered: boolean) => (el: HTMLDivElement | null) => {
+    if (!el || !workbook) return;
+    if (tables.current[sheet.sheetName] && (tables.current[sheet.sheetName] as any).destroy) {
+      (tables.current[sheet.sheetName] as any).destroy();
+    }
+    el.innerHTML = "";
+    setTimeout(() => {
+      const columns = [
+        ...sheet.columns.map((col: ExcelColumn, colIdx) => ({
+          title: col.name,
+          field: col.name,
+          headerContextMenu: [
+            {
+              label: "Rename Column",
+              action: () => {
+                openRenameDialog(sheet.sheetName, colIdx, col.name);
+              },
+              icon: () => {
+                return `<svg xmlns='http://www.w3.org/2000/svg' class='inline-block mr-1' width='16' height='16' fill='none' viewBox='0 0 24 24' stroke='currentColor'><path stroke-linecap='round' stroke-linejoin='round' stroke-width='2' d='M12 20h9'/><path d='M16.5 3.5a2.121 2.121 0 1 1 3 3L7 19.5 3 21l1.5-4L16.5 3.5z'/></svg>`;
+              },
+            },
+          ],
+        })),
+      ];
+      const dataRows = filtered
+        ? removeBlankRows(sheet.rows, sheet.columns, sheet.columns.map((c) => c.name))
+        : sheet.rows;
+      const data = dataRows.map((row: (string | number | null)[], idx) => {
         const obj: Record<string, string | number | null> = {};
         sheet.columns.forEach((col, i) => {
           obj[col.name] = row[i];
         });
+        obj['__rowIdx'] = idx;
         return obj;
       });
-      tables.current[sheet.sheetName] = new Tabulator(container, {
+      const table = new Tabulator(el, {
         data,
-        columns: sheet.columns.map((col) => ({ title: col.name, field: col.name })),
+        columns,
         layout: "fitDataTable",
+        rowFormatter: (row: any) => { },
+        rowContextMenu: [
+          {
+            label: "Delete Row",
+            action: function (e: MouseEvent, row: any) {
+              const rowIdx = row.getPosition();
+              handleDeleteRow(sheet.sheetName, rowIdx - 1);
+            },
+            icon: () => {
+              return `<svg xmlns='http://www.w3.org/2000/svg' class='inline-block mr-1' width='16' height='16' fill='none' viewBox='0 0 24 24' stroke='currentColor'><path stroke-linecap='round' stroke-linejoin='round' stroke-width='2' d='M6 18L18 6M6 6l12 12'/></svg>`;
+            },
+          },
+          {
+            label: "Use Row as Header",
+            action: function (e: MouseEvent, row: any) {
+              const rowIdx = row.getPosition();
+              handleUseRowAsHeader(sheet.sheetName, rowIdx - 1);
+            },
+            icon: () => {
+              return `<svg xmlns='http://www.w3.org/2000/svg' class='inline-block mr-1' width='16' height='16' fill='none' viewBox='0 0 24 24' stroke='currentColor'><path stroke-linecap='round' stroke-linejoin='round' stroke-width='2' d='M4 6h16M4 12h16M4 18h16'/></svg>`;
+            },
+          },
+        ],
       });
-    });
-
-    return () => {
-      Object.values(tables.current).forEach((t) => t.destroy && t.destroy());
-      tables.current = {};
-    };
-  }, [workbook]);
-
-  const handleSubmit = async () => {
-    if (!file) return;
-    await readExcel(file);
-    setFile(null);
+      tables.current[sheet.sheetName] = table;
+    }, 0);
   };
+
+  // Debug: log workbook and sheets
+  useEffect(() => {
+    if (workbook) {
+      console.log("[ExcelReader] workbook:", workbook);
+      if (workbook.sheets) {
+        console.log("[ExcelReader] sheets:", workbook.sheets);
+        workbook.sheets.forEach((sheet, idx) => {
+          console.log(`[ExcelReader] Sheet #${idx}:`, sheet.sheetName, sheet.columns, sheet.rows);
+        });
+      }
+    }
+  }, [workbook]);
 
   return (
     <div className="space-y-4">
@@ -74,28 +243,76 @@ export default function ExcelReaderPage() {
               disabled={!file || loading}
               className="gap-2"
             >
-              {loading && <Loader2 className="w-4 h-4 animate-spin" />}
-              <Upload className="w-4 h-4" /> Read
+              {loading && <span className="animate-spin">⏳</span>}
+              Read
             </Button>
           </div>
-          {workbook && (
-            <div className="space-y-8">
-              {workbook.sheets.map((sheet, idx) => (
-                <div key={sheet.sheetName} className="space-y-2">
-                  <h3 className="font-semibold">{sheet.sheetName}</h3>
-                  <div
-                    ref={(el) => {
-                      tableContainers.current[sheet.sheetName] = el;
-                    }}
-                    id={`table-${idx}`}
-                    className="w-full"
-                  />
-                </div>
-              ))}
-            </div>
+          {workbook && workbook.sheets.length > 0 && (
+            <>
+              <Tabs value={activeSheet || workbook.sheets[0].sheetName} onValueChange={setActiveSheet} className="w-full">
+                <TabsList className="mb-2">
+                  {workbook.sheets.map((sheet) => (
+                    <TabsTrigger key={sheet.sheetName} value={sheet.sheetName} className="capitalize">
+                      {sheet.sheetName}
+                    </TabsTrigger>
+                  ))}
+                </TabsList>
+                {workbook.sheets.map((sheet, idx) => (
+                  <TabsContent key={sheet.sheetName} value={sheet.sheetName} className="w-full">
+                    <div className="flex items-center gap-2 mb-2">
+                      <Button
+                        variant="destructive"
+                        onClick={() => handleRemoveRows(sheet.sheetName)}
+                        className="text-xs px-3 py-1"
+                      >
+                        Remove Empty Rows
+                      </Button>
+                    </div>
+                    <div
+                      ref={getTableRef(sheet, false)}
+                      id={`table-${idx}`}
+                      className="w-full min-h-[200px] border bg-white"
+                    />
+                  </TabsContent>
+                ))}
+              </Tabs>
+            </>
+          )}
+          {(!workbook || !workbook.sheets || workbook.sheets.length === 0) && !loading && (
+            <div className="text-center text-gray-500 py-8">No data to display. Please upload an Excel file.</div>
           )}
         </CardContent>
       </Card>
+      <Dialog open={renameDialogOpen} onOpenChange={setRenameDialogOpen}>
+        <DialogContent className="max-w-sm w-full">
+          <DialogHeader>
+            <DialogTitle>Rename Column</DialogTitle>
+          </DialogHeader>
+          <form
+            onSubmit={e => {
+              e.preventDefault();
+              handleRenameConfirm();
+            }}
+            className="space-y-4"
+          >
+            <ShadInput
+              autoFocus
+              value={renameValue}
+              onChange={e => setRenameValue(e.target.value)}
+              className="w-full"
+              placeholder="New column name"
+            />
+            <DialogFooter className="flex gap-2 justify-end">
+              <Button type="button" variant="outline" onClick={() => setRenameDialogOpen(false)}>
+                Cancel
+              </Button>
+              <Button type="submit" disabled={!renameValue.trim() || renameValue === renameCurrent}>
+                Rename
+              </Button>
+            </DialogFooter>
+          </form>
+        </DialogContent>
+      </Dialog>
     </div>
   );
 }

--- a/src/components/pages/ExcelReader.tsx
+++ b/src/components/pages/ExcelReader.tsx
@@ -1,0 +1,78 @@
+import { useState } from 'react';
+import { Upload, Loader2, FileSpreadsheet } from 'lucide-react';
+import { Button } from '@/components/ui/button';
+import { Card, CardHeader, CardTitle, CardContent } from '@/components/ui/card';
+import { Input } from '@/components/ui/input';
+import { useExcelStore } from '@/store/excelStore';
+
+export default function ExcelReaderPage() {
+  const { workbook, loading, readExcel } = useExcelStore();
+  const [file, setFile] = useState<File | null>(null);
+
+  const handleSubmit = async () => {
+    if (!file) return;
+    await readExcel(file);
+  };
+
+  return (
+    <div className="space-y-4">
+      <div className="flex items-center gap-2 text-2xl font-bold mb-4">
+        <FileSpreadsheet className="w-6 h-6" />
+        Excel Reader
+      </div>
+      <Card>
+        <CardHeader>
+          <CardTitle>Upload Excel</CardTitle>
+        </CardHeader>
+        <CardContent className="space-y-4">
+          <div className="flex items-center gap-2">
+            <Input
+              type="file"
+              accept=".xlsx"
+              onChange={(e) => setFile(e.target.files?.[0] ?? null)}
+            />
+            <Button
+              onClick={handleSubmit}
+              disabled={!file || loading}
+              className="gap-2"
+            >
+              {loading && <Loader2 className="w-4 h-4 animate-spin" />}
+              <Upload className="w-4 h-4" /> Read
+            </Button>
+          </div>
+          {workbook && (
+            <div className="overflow-auto">
+              {workbook.sheets.map((sheet) => (
+                <div key={sheet.sheetName} className="mb-6">
+                  <h3 className="font-semibold mb-2">{sheet.sheetName}</h3>
+                  <table className="w-full text-sm border">
+                    <thead className="bg-muted">
+                      <tr>
+                        {sheet.columns.map((col) => (
+                          <th key={col.name} className="p-2 text-left font-semibold">
+                            {col.name}
+                          </th>
+                        ))}
+                      </tr>
+                    </thead>
+                    <tbody>
+                      {sheet.rows.map((row, i) => (
+                        <tr key={i} className="border-t">
+                          {row.map((cell, j) => (
+                            <td key={j} className="p-2">
+                              {String(cell)}
+                            </td>
+                          ))}
+                        </tr>
+                      ))}
+                    </tbody>
+                  </table>
+                </div>
+              ))}
+            </div>
+          )}
+        </CardContent>
+      </Card>
+    </div>
+  );
+}

--- a/src/components/pages/ExcelReader.tsx
+++ b/src/components/pages/ExcelReader.tsx
@@ -1,6 +1,6 @@
-import { useState, useRef, useEffect } from 'react';
-import { TabulatorFull as Tabulator } from 'tabulator-tables';
-import 'tabulator-tables/dist/css/tabulator.min.css';
+import { useState, useRef, useEffect } from "react";
+import { TabulatorFull as Tabulator } from "tabulator-tables";
+import "tabulator-tables/dist/css/tabulator.min.css";
 import { Upload, Loader2, FileSpreadsheet } from 'lucide-react';
 import { Button } from '@/components/ui/button';
 import { Card, CardHeader, CardTitle, CardContent } from '@/components/ui/card';
@@ -11,12 +11,15 @@ export default function ExcelReaderPage() {
   const { workbook, loading, readExcel } = useExcelStore();
   const [file, setFile] = useState<File | null>(null);
   const tableContainers = useRef<Record<string, HTMLDivElement | null>>({});
-  const tables = useRef<Record<string, any>>({});
+  interface TabulatorInstance {
+    destroy?: () => void;
+  }
+  const tables = useRef<Record<string, TabulatorInstance>>({});
 
   useEffect(() => {
     if (!workbook) return;
 
-    workbook.sheets.forEach((sheet, idx) => {
+    workbook.sheets.forEach((sheet) => {
       const container = tableContainers.current[sheet.sheetName];
       if (!container) return;
       if (tables.current[sheet.sheetName]) {
@@ -32,7 +35,7 @@ export default function ExcelReaderPage() {
       tables.current[sheet.sheetName] = new Tabulator(container, {
         data,
         columns: sheet.columns.map((col) => ({ title: col.name, field: col.name })),
-        layout: 'fitDataTable',
+        layout: "fitDataTable",
       });
     });
 
@@ -79,7 +82,12 @@ export default function ExcelReaderPage() {
               {workbook.sheets.map((sheet, idx) => (
                 <div key={sheet.sheetName} className="space-y-2">
                   <h3 className="font-semibold">{sheet.sheetName}</h3>
-                  <div ref={(el) => (tableContainers.current[sheet.sheetName] = el)} id={`table-${idx}`} />
+                  <div
+                    ref={(el) => {
+                      tableContainers.current[sheet.sheetName] = el;
+                    }}
+                    id={`table-${idx}`}
+                  />
                 </div>
               ))}
             </div>

--- a/src/components/pages/ExcelReader.tsx
+++ b/src/components/pages/ExcelReader.tsx
@@ -1,4 +1,4 @@
-import { useState, useRef, useEffect } from "react";
+import { useState, useRef, useLayoutEffect } from "react";
 import { TabulatorFull as Tabulator } from "tabulator-tables";
 import "tabulator-tables/dist/css/tabulator.min.css";
 import { Upload, Loader2, FileSpreadsheet } from 'lucide-react';
@@ -16,7 +16,7 @@ export default function ExcelReaderPage() {
   }
   const tables = useRef<Record<string, TabulatorInstance>>({});
 
-  useEffect(() => {
+  useLayoutEffect(() => {
     if (!workbook) return;
 
     workbook.sheets.forEach((sheet) => {
@@ -88,6 +88,7 @@ export default function ExcelReaderPage() {
                       tableContainers.current[sheet.sheetName] = el;
                     }}
                     id={`table-${idx}`}
+                    className="w-full"
                   />
                 </div>
               ))}

--- a/src/components/pages/ExcelReader.tsx
+++ b/src/components/pages/ExcelReader.tsx
@@ -45,6 +45,7 @@ export default function ExcelReaderPage() {
   const handleSubmit = async () => {
     if (!file) return;
     await readExcel(file);
+    setFile(null);
   };
 
   return (

--- a/src/components/ui/tabs.tsx
+++ b/src/components/ui/tabs.tsx
@@ -1,0 +1,64 @@
+import * as React from "react"
+import * as TabsPrimitive from "@radix-ui/react-tabs"
+
+import { cn } from "@/lib/utils"
+
+function Tabs({
+  className,
+  ...props
+}: React.ComponentProps<typeof TabsPrimitive.Root>) {
+  return (
+    <TabsPrimitive.Root
+      data-slot="tabs"
+      className={cn("flex flex-col gap-2", className)}
+      {...props}
+    />
+  )
+}
+
+function TabsList({
+  className,
+  ...props
+}: React.ComponentProps<typeof TabsPrimitive.List>) {
+  return (
+    <TabsPrimitive.List
+      data-slot="tabs-list"
+      className={cn(
+        "bg-muted text-muted-foreground inline-flex h-9 w-fit items-center justify-center rounded-lg p-[3px]",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function TabsTrigger({
+  className,
+  ...props
+}: React.ComponentProps<typeof TabsPrimitive.Trigger>) {
+  return (
+    <TabsPrimitive.Trigger
+      data-slot="tabs-trigger"
+      className={cn(
+        "data-[state=active]:bg-background dark:data-[state=active]:text-foreground focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:outline-ring dark:data-[state=active]:border-input dark:data-[state=active]:bg-input/30 text-foreground dark:text-muted-foreground inline-flex h-[calc(100%-1px)] flex-1 items-center justify-center gap-1.5 rounded-md border border-transparent px-2 py-1 text-sm font-medium whitespace-nowrap transition-[color,box-shadow] focus-visible:ring-[3px] focus-visible:outline-1 disabled:pointer-events-none disabled:opacity-50 data-[state=active]:shadow-sm [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function TabsContent({
+  className,
+  ...props
+}: React.ComponentProps<typeof TabsPrimitive.Content>) {
+  return (
+    <TabsPrimitive.Content
+      data-slot="tabs-content"
+      className={cn("flex-1 outline-none", className)}
+      {...props}
+    />
+  )
+}
+
+export { Tabs, TabsList, TabsTrigger, TabsContent }

--- a/src/lib/api/excel/endpoints.ts
+++ b/src/lib/api/excel/endpoints.ts
@@ -1,0 +1,5 @@
+import { EXCEL_API_BASE_URL } from "../index";
+
+export const ExcelEndpoints = {
+  read: `${EXCEL_API_BASE_URL}/read-excel`,
+};

--- a/src/lib/api/excel/service.ts
+++ b/src/lib/api/excel/service.ts
@@ -1,5 +1,4 @@
 import axios from "axios";
-import type { ApiResponse } from "../models/api-response.model";
 import type { ExcelWorkbook } from "../models/excel-workbook.model";
 import { ExcelEndpoints } from "./endpoints";
 import { createAuthConfig } from "../helpers";
@@ -9,7 +8,7 @@ export const ExcelService = {
     file: File,
     token: string,
     tenantId: string
-  ): Promise<ApiResponse<ExcelWorkbook>> => {
+  ): Promise<ExcelWorkbook> => {
     const formData = new FormData();
     formData.append("file", file);
 

--- a/src/lib/api/excel/service.ts
+++ b/src/lib/api/excel/service.ts
@@ -1,0 +1,22 @@
+import axios from "axios";
+import type { ApiResponse } from "../models/api-response.model";
+import type { ExcelWorkbook } from "../models/excel-workbook.model";
+import { ExcelEndpoints } from "./endpoints";
+import { createAuthConfig } from "../helpers";
+
+export const ExcelService = {
+  read: async (
+    file: File,
+    token: string,
+    tenantId: string
+  ): Promise<ApiResponse<ExcelWorkbook>> => {
+    const formData = new FormData();
+    formData.append("file", file);
+
+    const config = createAuthConfig(token, tenantId);
+    const headers = { ...config.headers, "Content-Type": "multipart/form-data" };
+
+    const response = await axios.post(ExcelEndpoints.read, formData, { headers });
+    return response.data;
+  },
+};

--- a/src/lib/api/index.ts
+++ b/src/lib/api/index.ts
@@ -2,8 +2,10 @@
 export const API_BASE_URL = "https://localhost:5081/api";
 export const APPLICATION_API_BASE_URL = "https://localhost:5091/api";
 export const FILE_API_BASE_URL = "https://localhost:5085/api";
+export const EXCEL_API_BASE_URL = "http://localhost:5093";
 export const DEFAULT_TENANT_ID = "11111111-1111-1111-1111-111111111111";
 export const DEFAULT_FAILED_TENANT_ID = "11111111-1111-1111-1111-111111111112";
 export { createAuthConfig, createAuthHeaders } from "./helpers";
 export type { ApplicationSaveRequest } from "./models/application-save-request.model";
 export type { FileItem } from "./models/file.model";
+export type { ExcelWorkbook } from "./models/excel-workbook.model";

--- a/src/lib/api/models/excel-workbook.model.ts
+++ b/src/lib/api/models/excel-workbook.model.ts
@@ -1,0 +1,17 @@
+export interface ExcelColumn {
+  name: string;
+  dataType: string;
+  format: string;
+  formula: string | null;
+}
+
+export interface ExcelSheet {
+  sheetName: string;
+  columns: ExcelColumn[];
+  rows: Array<Array<string | number | null>>;
+}
+
+export interface ExcelWorkbook {
+  workbookName: string;
+  sheets: ExcelSheet[];
+}

--- a/src/store/excelStore.test.ts
+++ b/src/store/excelStore.test.ts
@@ -31,8 +31,9 @@ describe('useExcelStore', () => {
   });
 
   it('readExcel posts data and sets workbook', async () => {
-    await useExcelStore.getState().readExcel({} as File);
+    const result = await useExcelStore.getState().readExcel({} as File);
     expect(ExcelService.read).toHaveBeenCalledWith({} as File, 'tok', 'tenant1');
+    expect(result.workbookName).toBe('test.xlsx');
     expect(useExcelStore.getState().workbook?.workbookName).toBe('test.xlsx');
     expect(useExcelStore.getState().loading).toBe(false);
   });

--- a/src/store/excelStore.test.ts
+++ b/src/store/excelStore.test.ts
@@ -1,0 +1,39 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { useExcelStore } from './excelStore';
+import { useAuthStore } from './authStore';
+import { ExcelService } from '@/lib/api/excel/service';
+
+const sample = {
+  workbookName: 'test.xlsx',
+  sheets: [],
+};
+
+vi.mock('@/lib/api/excel/service', () => ({
+  ExcelService: {
+    read: vi.fn().mockResolvedValue({ data: sample }),
+  },
+}));
+
+describe('useExcelStore', () => {
+  beforeEach(() => {
+    useExcelStore.setState({ workbook: null, loading: false });
+    useAuthStore.setState({ token: 'tok', tenantId: 'tenant1' });
+  });
+
+  it('sets workbook', () => {
+    useExcelStore.getState().setWorkbook(sample as any);
+    expect(useExcelStore.getState().workbook?.workbookName).toBe('test.xlsx');
+  });
+
+  it('setLoading updates loading state', () => {
+    useExcelStore.getState().setLoading(true);
+    expect(useExcelStore.getState().loading).toBe(true);
+  });
+
+  it('readExcel posts data and sets workbook', async () => {
+    await useExcelStore.getState().readExcel({} as File);
+    expect(ExcelService.read).toHaveBeenCalledWith({} as File, 'tok', 'tenant1');
+    expect(useExcelStore.getState().workbook?.workbookName).toBe('test.xlsx');
+    expect(useExcelStore.getState().loading).toBe(false);
+  });
+});

--- a/src/store/excelStore.ts
+++ b/src/store/excelStore.ts
@@ -8,7 +8,7 @@ interface ExcelState {
   loading: boolean;
   setWorkbook: (wb: ExcelWorkbook | null) => void;
   setLoading: (loading: boolean) => void;
-  readExcel: (file: File) => Promise<void>;
+  readExcel: (file: File) => Promise<ExcelWorkbook>;
 }
 
 export const useExcelStore = create<ExcelState>((set) => ({
@@ -22,6 +22,7 @@ export const useExcelStore = create<ExcelState>((set) => ({
       const { token, tenantId } = useAuthStore.getState();
       const res = await ExcelService.read(file, token, tenantId);
       set({ workbook: res.data });
+      return res.data;
     } finally {
       set({ loading: false });
     }

--- a/src/store/excelStore.ts
+++ b/src/store/excelStore.ts
@@ -1,0 +1,29 @@
+import { create } from "zustand";
+import { ExcelService } from "@/lib/api/excel/service";
+import type { ExcelWorkbook } from "@/lib/api";
+import { useAuthStore } from "./authStore";
+
+interface ExcelState {
+  workbook: ExcelWorkbook | null;
+  loading: boolean;
+  setWorkbook: (wb: ExcelWorkbook | null) => void;
+  setLoading: (loading: boolean) => void;
+  readExcel: (file: File) => Promise<void>;
+}
+
+export const useExcelStore = create<ExcelState>((set) => ({
+  workbook: null,
+  loading: false,
+  setWorkbook: (wb) => set({ workbook: wb }),
+  setLoading: (loading) => set({ loading }),
+  readExcel: async (file: File) => {
+    set({ loading: true });
+    try {
+      const { token, tenantId } = useAuthStore.getState();
+      const res = await ExcelService.read(file, token, tenantId);
+      set({ workbook: res.data });
+    } finally {
+      set({ loading: false });
+    }
+  },
+}));

--- a/src/types/tabulator-tables.d.ts
+++ b/src/types/tabulator-tables.d.ts
@@ -1,0 +1,1 @@
+declare module 'tabulator-tables';


### PR DESCRIPTION
## Summary
- expose new `EXCEL_API_BASE_URL` and `ExcelWorkbook` type
- add Excel service and endpoints
- create zustand store with tests
- add Excel reader page and sidebar route

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_686748b0b30c8328962e93b7c3e6142b